### PR TITLE
Security section update to align with the content of the draft

### DIFF
--- a/draft-ietf-netconf-list-pagination-nc.xml
+++ b/draft-ietf-netconf-list-pagination-nc.xml
@@ -255,10 +255,11 @@ RFC: XXXX</artwork>
         particular NETCONF users to a preconfigured subset of all available
         NETCONF protocol operations and content.</t>
 
-        <t>The security considerations for the base NETCONF protocol
-        operations (see Section 9 of <xref target="RFC6241"/> apply to the new
-        &lt;get-list-pagination&gt; RPC operations defined in this
-        document.</t>
+        <t>The security considerations for the base NETCONF protocol operations
+        (see Section 9 of <xref target="RFC6241"/> and Section 6 of 
+        <xref target="RFC8526"/>) apply to extension to operations &lt;get&gt;,
+        &lt;get-config&gt;,&lt;get-data&gt; operations defined in this document.
+        </t>
       </section>
     </section>
   </middle>


### PR DESCRIPTION
Update Security Section and remove new rpc operation <get-list-pagination> with extension to operations <get>,<get-config>,<get-data>.  Add reference to section 6 of RFC8526.