### PR TITLE
Update where and sort-by to use correct node

### DIFF
--- a/includes/ex-api-combo-rpc.xml
+++ b/includes/ex-api-combo-rpc.xml
@@ -7,8 +7,8 @@
       xmlns:es="https://example.com/ns/example-social"/>
     <list-pagination
       xmlns="urn:ietf:params:xml:ns:yang:ietf-list-pagination-nc">
-      <where>//stats//joined[starts-with(timestamp,'2020')]</where>
-      <sort-by>timestamp</sort-by>
+      <where>//stats[starts-with(joined,'2020')]</where>
+      <sort-by>joined</sort-by>
       <direction>backwards</direction>
       <offset>2</offset>
       <limit>2</limit>


### PR DESCRIPTION
There is no "timestamp" node in the /example-social:member/stats container, assuming "joined" was the intended node.

This needs the linked issue to be fixed.

See: netconf-wg/list-pagination#12