### PR TITLE
Kwatsen patch 1

### DIFF
--- a/draft-ietf-netconf-list-pagination-nc.xml
+++ b/draft-ietf-netconf-list-pagination-nc.xml
@@ -189,7 +189,7 @@ INSERT_TEXT_FROM_FILE(includes/tree-ietf-list-pagination-nc.txt)
             target="I-D.ietf-netconf-list-pagination"/>.</t>
           <t>If the limit value is invalid, i.e. not an unsigned 32-bit integer
             greater than or equal to 1 or the string "unbounded", then an
-            &lt;rfc-error&gt; MUST be returned with the error-type
+            &lt;rpc-error&gt; MUST be returned with the error-type
             value "application" and error-tag value "invalid-value".</t>
         </section>
 
@@ -197,11 +197,11 @@ INSERT_TEXT_FROM_FILE(includes/tree-ietf-list-pagination-nc.txt)
           <t>The "offset" RPC input parameter corresponds to the "offset"
             parameter defined in <relref section="3.1.5"
             target="I-D.ietf-netconf-list-pagination"/>.</t>
-          <t>If the offset value is invalid, an &lt;rfc-error&gt;
+          <t>If the offset value is invalid, an &lt;rpc-error&gt;
             MUST be returned with the error-type value "application" and
             error-tag value "invalid-value".</t>
           <t>If the offset value exceeds the number of entries in the
-            working result set, then the &lt;rfc-error&gt; SHOULD also
+            working result set, then the &lt;rpc-error&gt; SHOULD also
             include the "offset-out-of-range" identity as the error-app-tag
             value.</t>
         </section>
@@ -215,12 +215,12 @@ INSERT_TEXT_FROM_FILE(includes/tree-ietf-list-pagination-nc.txt)
             and "previous" cursor or the current page. Due to their ephemeral
             nature, cursor values are never cached.</t>
           <t>If the cursor value is unknown, i.e. the key does not exist,
-            an &lt;rfc-error&gt; MUST be returned with the error-type
+            an &lt;rpc-error&gt; MUST be returned with the error-type
             value "application" and error-tag value "invalid-value", and SHOULD
             also include the "cursor-not-found" identity as the error-app-tag
             value.</t>
           <t>If the "cursor" RPC input parameter is not supported on the target
-            node, then the &lt;rfc-error&gt; MUST be returned with error-type
+            node, then the &lt;rpc-error&gt; MUST be returned with error-type
             value "application" and error-tag value "operation-not-supported".</t>
         </section>
 
@@ -228,7 +228,7 @@ INSERT_TEXT_FROM_FILE(includes/tree-ietf-list-pagination-nc.txt)
           <t>The "direction" RPC input parameter corresponds to the "direction"
             parameter defined in <relref section="3.1.4"
             target="I-D.ietf-netconf-list-pagination"/>.</t>
-          <t>If the direction value is invalid, then an &lt;rfc-error&gt;
+          <t>If the direction value is invalid, then an &lt;rpc-error&gt;
              MUST be returned with the error-type value
             "application" and error-tag value "invalid-value".</t>
         </section>
@@ -237,7 +237,7 @@ INSERT_TEXT_FROM_FILE(includes/tree-ietf-list-pagination-nc.txt)
           <t>The "sort-by" RPC input parameter corresponds to the "sort-by"
             parameter defined in <relref section="3.1.2"
             target="I-D.ietf-netconf-list-pagination"/>.</t>
-          <t>If the specified node identifier is invalid, then an &lt;rfc-error&gt;
+          <t>If the specified node identifier is invalid, then an &lt;rpc-error&gt;
             MUST be returned with the error-type value "application" and error-tag
             value "invalid-value".</t>
         </section>
@@ -247,12 +247,12 @@ INSERT_TEXT_FROM_FILE(includes/tree-ietf-list-pagination-nc.txt)
             "locale" parameter defined in <relref section="3.1.3"
             target="I-D.ietf-netconf-list-pagination"/>.</t>
           <t>If the specified node identifier is invalid, i.e. the locale is
-            unknown to the server, then an &lt;rfc-error&gt; MUST be
+            unknown to the server, then an &lt;rpc-error&gt; MUST be
             returned with the error-type value "application" and
             error-tag value "invalid-value", and SHOULD also include the
             "locale-unavailable" identity as the error-app-tag value.</t>
           <!-- not needed anymore with new YANG 'when' expression? remove from -rc draft too?
-          <t>If "locale" is supplied but not "sort-by", the &lt;rfc-error&gt;
+          <t>If "locale" is supplied but not "sort-by", the &lt;rpc-error&gt;
             MUST have the error-type "application" and error-tag value
             "invalid-value".</t>
           -->
@@ -273,7 +273,7 @@ INSERT_TEXT_FROM_FILE(includes/tree-ietf-list-pagination-nc.txt)
             be prefix of the associated source module, as described by
             <xref section="7.1.4" target="RFC7950"/>.</t>
 
-          <t>If the specified XPath expression is invalid, then an &lt;rfc-error&gt;
+          <t>If the specified XPath expression is invalid, then an &lt;rpc-error&gt;
             MUST be returned with the error-type value "application" and error-tag
             value "invalid-value".</t>
         </section>
@@ -282,7 +282,7 @@ INSERT_TEXT_FROM_FILE(includes/tree-ietf-list-pagination-nc.txt)
           <t>The "sublist-limit" RPC input parameter corresponds to the
             "sublist-limit" parameter defined in <relref section="3.2.1"
             target="I-D.ietf-netconf-list-pagination"/>.</t>
-          <t>If the sublist-limit value is invalid, then an &lt;rfc-error&gt;
+          <t>If the sublist-limit value is invalid, then an &lt;rpc-error&gt;
             MUST be returned with the error-type value "application" and
             error-tag value "invalid-value".</t>
         </section>

--- a/draft-ietf-netconf-list-pagination-nc.xml
+++ b/draft-ietf-netconf-list-pagination-nc.xml
@@ -147,27 +147,9 @@
     <section title="List Pagination for NETCONF" anchor="solution">
       <t>In order for NETCONF to support <xref target="I-D.ietf-netconf-list-pagination"/>,
       this document extends the operations &lt;get&gt;, &lt;get-config&gt; and &lt;get-data&gt;
-      to include additional input parameters and output annotations.</t>
-
-      <t>The updated operations accept a content filter parameter "where", similar to the
-      "filter" parameter of &lt;get-config&gt;, but includes nodes for "list" and
-      "leaf-list" filtering.</t>
-
-      <t>The "where" RPC input parameter is used to specify the YANG list or leaf-list
-      that is to be retrieved. This must be a path expression used to represent a
-      list or leaf-list data node.</t>
-
-      <t> XPath expression in the "where" RPC input parameter is evaluated according to
-      the validation rules defined in section 8.9.1 of RFC6241. Note that Prefixes in the
-      "where" RPC input parameter XPath expression should but needn't be the same YANG module
-      prefixes associated with the YANG modules since YANG module prefixes aren't guaranteed
-      to be unique. Prefixes used in filters have to be declared as XML namespace prefixes
-      bound to the namespace URIs of corresponding YANG modules. The context node for
-      evaluation MUST be the list node.
-</t>
-
-      <t>The following tree diagram <xref target="RFC8340"/> illustrates the
-        "ietf-netconf-list-pagination" module:</t>
+      to include additional input parameters and output annotations, as described by the
+      following tree diagram <xref target="RFC8340"/> for the "ietf-netconf-list-pagination"
+      module:</t>
       <t>
         <figure>
          <artwork><![CDATA[
@@ -183,6 +165,128 @@ INSERT_TEXT_FROM_FILE(includes/tree-ietf-list-pagination-nc.txt)
           defined in <xref target="RFC6241"/>.  The "get-data" augment is
           against the YANG module defined in <xref target="RFC8526"/>.</li>
       </ul>
+
+      <section title="RPC Input Parameters">
+        <t>These eight RPC input parameters, corresponding to those defined in
+          Sections 3.1 and 3.2 in <xref target="I-D.ietf-netconf-list-pagination"/>
+          are grouped under a container called "list-pagination", which is
+          only allowed to appear if the "filter" RPC input parameter targets
+          a "list" or "leaf-list" node supporting list pagination.</t>
+        <t>Per the conformance defined in <relref section="3.1"
+          target="I-D.ietf-netconf-list-pagination"/>,
+          all of these parameters MUST be supported for all "config true" lists
+          and leaf-lists, and SHOULD be supported for "config false" lists and
+          leaf-lists. A server MAY disable the support for some or all
+          "config false" lists, as described in <relref section="3.3"
+          target="I-D.ietf-netconf-list-pagination"/>.</t>
+        <t>Note that complex pagination with combination of RPC input parameters
+          may cause performance strain on constrained devices due to intensive
+          processing on both the server and the client.</t>
+
+        <section title='The "limit" RPC Input Parameter'>
+          <t>The "limit" RPC input parameter corresponds to the "limit"
+            parameter defined in <relref section="3.1.7"
+            target="I-D.ietf-netconf-list-pagination"/>.</t>
+          <t>If the limit value is invalid, i.e. not an unsigned 32-bit integer
+            greater than or equal to 1 or the string "unbounded", then an
+            &lt;rfc-error&gt; MUST be returned with the error-type
+            value "application" and error-tag value "invalid-value".</t>
+        </section>
+
+        <section title='The "offset" RPC Input Parameter'>
+          <t>The "offset" RPC input parameter corresponds to the "offset"
+            parameter defined in <relref section="3.1.5"
+            target="I-D.ietf-netconf-list-pagination"/>.</t>
+          <t>If the offset value is invalid, an &lt;rfc-error&gt;
+            MUST be returned with the error-type value "application" and
+            error-tag value "invalid-value".</t>
+          <t>If the offset value exceeds the number of entries in the
+            working result set, then the &lt;rfc-error&gt; SHOULD also
+            include the "offset-out-of-range" identity as the error-app-tag
+            value.</t>
+        </section>
+
+        <section title='The "cursor" RPC Input Parameter'>
+          <t>The "cursor" RPC input parameter corresponds to the "cursor"
+            parameter defined in <relref section="3.1.6"
+            target="I-D.ietf-netconf-list-pagination"/>. As described in
+            <relref section="3.1.5" target="I-D.ietf-netconf-list-pagination"/>
+            the server does not keep any stateful information about the "next"
+            and "previous" cursor or the current page. Due to their ephemeral
+            nature, cursor values are never cached.</t>
+          <t>If the cursor value is unknown, i.e. the key does not exist,
+            an &lt;rfc-error&gt; MUST be returned with the error-type
+            value "application" and error-tag value "invalid-value", and SHOULD
+            also include the "cursor-not-found" identity as the error-app-tag
+            value.</t>
+          <t>If the "cursor" RPC input parameter is not supported on the target
+            node, then the &lt;rfc-error&gt; MUST be returned with error-type
+            value "application" and error-tag value "operation-not-supported".</t>
+        </section>
+
+        <section title='The "direction" RPC Input Parameter'>
+          <t>The "direction" RPC input parameter corresponds to the "direction"
+            parameter defined in <relref section="3.1.4"
+            target="I-D.ietf-netconf-list-pagination"/>.</t>
+          <t>If the direction value is invalid, then an &lt;rfc-error&gt;
+             MUST be returned with the error-type value
+            "application" and error-tag value "invalid-value".</t>
+        </section>
+
+        <section title='The "sort-by" RPC Input Parameter'>
+          <t>The "sort-by" RPC input parameter corresponds to the "sort-by"
+            parameter defined in <relref section="3.1.2"
+            target="I-D.ietf-netconf-list-pagination"/>.</t>
+          <t>If the specified node identifier is invalid, then an &lt;rfc-error&gt;
+            MUST be returned with the error-type value "application" and error-tag
+            value "invalid-value".</t>
+        </section>
+
+        <section title='The "locale" RPC Input Parameter'>
+          <t>The "locale" RPC input parameter corresponds to the
+            "locale" parameter defined in <relref section="3.1.3"
+            target="I-D.ietf-netconf-list-pagination"/>.</t>
+          <t>If the specified node identifier is invalid, i.e. the locale is
+            unknown to the server, then an &lt;rfc-error&gt; MUST be
+            returned with the error-type value "application" and
+            error-tag value "invalid-value", and SHOULD also include the
+            "locale-unavailable" identity as the error-app-tag value.</t>
+          <!-- not needed anymore with new YANG 'when' expression? remove from -rc draft too?
+          <t>If "locale" is supplied but not "sort-by", the &lt;rfc-error&gt;
+            MUST have the error-type "application" and error-tag value
+            "invalid-value".</t>
+          -->
+        </section>
+
+        <section title='The "where" RPC Input Parameter'>
+          <t>The "where" RPC input parameter corresponds to the "where"
+            parameter defined in <relref section="3.1.1"
+            target="I-D.ietf-netconf-list-pagination"/>.</t>
+
+          <t>The XPath expression in the "where" RPC input parameter is
+            evaluated according to the validation rules defined in
+            <xref section="8.9.1" target="RFC6241"/>, with the context
+            node being the targeted list node.</t>
+
+          <t>Prefixes MUST be declared as XML namespace prefixes bound to the
+            namespace URIs of corresponding YANG modules.  The prefix SHOULD
+            be prefix of the associated source module, as described by
+            <xref section="7.1.4" target="RFC7950"/>.</t>
+
+          <t>If the specified XPath expression is invalid, then an &lt;rfc-error&gt;
+            MUST be returned with the error-type value "application" and error-tag
+            value "invalid-value".</t>
+        </section>
+
+        <section title='The "sublist-limit" RPC Input Parameter'>
+          <t>The "sublist-limit" RPC input parameter corresponds to the
+            "sublist-limit" parameter defined in <relref section="3.2.1"
+            target="I-D.ietf-netconf-list-pagination"/>.</t>
+          <t>If the sublist-limit value is invalid, then an &lt;rfc-error&gt;
+            MUST be returned with the error-type value "application" and
+            error-tag value "invalid-value".</t>
+        </section>
+      </section>
     </section>
 
     <section title="Error Reporting" anchor="error-reporting">


### PR DESCRIPTION
This PR's branch is based on Qin's branch (so all commits there carry forward)
I was going to commit directly in Qin's branch, but somehow that seemed rude - lol

This PR introduces a pretty big reorganization to the document.  But, honestly,
the document's organization needed help.  The ToC was bad, and the `Introduction`
section was mostly about the `where` parameter.

I copied/pasted/edited most everything from the -rc document.

I do question why rules around common error values are not defined in the top-level
document and, if done, then the nc/rc docs could be simplified...

I recognize that these are big changes in a WGLC, but feel it's necessary after
reviewing the current state of things.  As an aside, this wouldn't have happened
if we had branch-rules configured, or regular meetings...